### PR TITLE
ci: actually run integration tests — add -tags integration and fixtur…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,23 +186,59 @@ jobs:
     - name: Run unit tests
       run: go test -v -short ./cmd/ghost-mcp/... || true
 
+    - name: Start fixture server and browser (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        # Start the fixture HTTP server in the background
+        go run ./cmd/ghost-mcp/test_fixture/fixture_server.go &
+        # Poll until it responds (up to 15 s)
+        for i in $(seq 1 15); do
+          curl -sf http://localhost:8765 > /dev/null && echo "Fixture server ready" && break
+          sleep 1
+        done
+        # Open Google Chrome on the Xvfb display so OCR tests can see the fixture UI
+        DISPLAY=:99 google-chrome --no-sandbox --disable-gpu http://localhost:8765 &
+        sleep 3
+
     - name: Run integration tests (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
         export INTEGRATION=1
-        go test -v -run Integration ./cmd/ghost-mcp/...
+        go test -v -tags integration -run TestIntegration ./cmd/ghost-mcp/...
 
-    - name: Run integration tests (macOS)
-      if: matrix.os == 'macos-latest'
+    - name: Start fixture server and browser (Windows)
+      if: matrix.os == 'windows-latest'
       run: |
-        export INTEGRATION=1
-        go test -v -run Integration ./cmd/ghost-mcp/... || true
+        # Start the fixture HTTP server in the background
+        Start-Process -FilePath "go" `
+          -ArgumentList "run", "./cmd/ghost-mcp/test_fixture/fixture_server.go" `
+          -WindowStyle Hidden
+        # Poll until it responds (up to 15 s)
+        $ready = $false
+        for ($i = 0; $i -lt 15; $i++) {
+          try {
+            Invoke-WebRequest "http://localhost:8765" -UseBasicParsing -ErrorAction Stop | Out-Null
+            $ready = $true
+            Write-Host "Fixture server ready"
+            break
+          } catch { Start-Sleep 1 }
+        }
+        if (-not $ready) { Write-Warning "Fixture server did not respond in time" }
+        # Open Edge on the runner display so OCR tests can see the fixture UI
+        Start-Process "msedge" -ArgumentList "http://localhost:8765"
+        Start-Sleep 3
 
     - name: Run integration tests (Windows)
       if: matrix.os == 'windows-latest'
       run: |
         $env:INTEGRATION = "1"
-        go test -v -run Integration ./cmd/ghost-mcp/...
+        go test -v -tags integration -run TestIntegration ./cmd/ghost-mcp/...
+
+    - name: Run integration tests (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        export INTEGRATION=1
+        go test -v -tags integration -run TestIntegration ./cmd/ghost-mcp/... || true
 
     - name: Run linting
       if: matrix.os != 'macos-latest'

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -135,7 +135,7 @@ test_runner.bat integration
 # Direct go test
 set INTEGRATION=1  # Windows
 export INTEGRATION=1  # macOS/Linux
-go test -v -run Integration ./...
+go test -v -tags integration -run TestIntegration ./...
 ```
 
 #### All Tests
@@ -456,7 +456,7 @@ jobs:
         Xvfb :99 &
         export DISPLAY=:99
         export INTEGRATION=1
-        go test -v -run Integration ./...
+        go test -v -tags integration -run TestIntegration ./...
 ```
 
 ## Test Coverage

--- a/test_runner.bat
+++ b/test_runner.bat
@@ -132,7 +132,7 @@ if "%TEST_TYPE%"=="integration" (
     echo [INFO] Running integration tests...
     echo.
     set INTEGRATION=1
-    go test -v -run Integration ./cmd/ghost-mcp/...
+    go test -v -tags integration -run TestIntegration ./cmd/ghost-mcp/...
     goto :summary
 )
 
@@ -163,7 +163,7 @@ if "%TEST_TYPE%"=="all" (
     timeout /t 3 /nobreak >nul
 
     set INTEGRATION=1
-    go test -v -run Integration ./cmd/ghost-mcp/...
+    go test -v -tags integration -run TestIntegration ./cmd/ghost-mcp/...
     goto :summary
 )
 

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -119,7 +119,7 @@ if [ "$TEST_TYPE" == "integration" ]; then
 
     echo "[INFO] Running integration tests..."
     echo ""
-    INTEGRATION=1 go test -v -run Integration ./cmd/ghost-mcp/...
+    INTEGRATION=1 go test -v -tags integration -run TestIntegration ./cmd/ghost-mcp/...
     goto_summary
 fi
 
@@ -152,7 +152,7 @@ if [ "$TEST_TYPE" == "all" ]; then
     # Ensure cleanup on exit
     trap "kill $FIXTURE_PID 2>/dev/null || true" EXIT
 
-    INTEGRATION=1 go test -v -run Integration ./cmd/ghost-mcp/...
+    INTEGRATION=1 go test -v -tags integration -run TestIntegration ./cmd/ghost-mcp/...
     goto_summary
 fi
 


### PR DESCRIPTION
…e setup

Integration tests were silently never executing because integration_test.go is guarded by //go:build integration. Without -tags integration the file is excluded from compilation entirely, so -run TestIntegration matched nothing and the step exited clean with [no tests to run].

Fixture-dependent tests (FindAndClick*, WaitForText, FullWorkflow) also need the fixture HTTP server running AND a browser window open on the display so screen capture / OCR can see the fixture UI.

Changes:
- test.yml: add -tags integration to all three integration test steps (Linux, Windows, macOS). Add "Start fixture server and browser" steps on Linux (google-chrome on Xvfb) and Windows (msedge) before the test run. Both steps poll http://localhost:8765 until the fixture server is ready before opening the browser.
- test_runner.bat / test_runner.sh: same fix — add -tags integration and update the -run pattern to TestIntegration (the actual function prefix).
- docs/TESTING.md: update direct go test examples to include the flag.