### PR TITLE
ci: expand coverage to all packages and add Codecov badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,13 +270,13 @@ jobs:
     - name: Test coverage (Linux only)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        go test -v -short -coverprofile=coverage.out ./cmd/ghost-mcp/...
-        go tool cover -func=coverage.out
+        go test -short -coverprofile=coverage.txt ./cmd/ghost-mcp/... ./internal/...
+        go tool cover -func=coverage.txt
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25'
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:
-        files: ./coverage.out
+        files: ./coverage.txt
         flags: unittests
         name: codecov-umbrella

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 **License:** Free for personal and hobby use ([PolyForm Noncommercial](LICENSE)). Commercial use requires a license — contact [Peter Isberg](mailto:isberg.peter+gm@gmail.com).
 
+[![codecov](https://codecov.io/gh/PIsberg/ghost-mcp/graph/badge.svg)](https://codecov.io/gh/PIsberg/ghost-mcp)
 
 ## Overview
 


### PR DESCRIPTION
- Run go test with -coverprofile=coverage.txt across ./cmd/ghost-mcp/... and ./internal/...
- Rename output from coverage.out to coverage.txt (Codecov standard)
- Add Codecov badge to README.md