### PR TITLE
test: add tests to improve coverage from 58% to ~70%+

### DIFF
--- a/internal/audit/audit_hooks_test.go
+++ b/internal/audit/audit_hooks_test.go
@@ -1,0 +1,221 @@
+// audit_hooks_test.go — Tests for RegisterHooks and extractToolResultError.
+package audit
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// =============================================================================
+// extractToolResultError
+// =============================================================================
+
+func TestExtractToolResultError_Nil(t *testing.T) {
+	got := extractToolResultError(nil)
+	if got != "unknown tool error" {
+		t.Errorf("expected %q, got %q", "unknown tool error", got)
+	}
+}
+
+func TestExtractToolResultError_EmptyContent(t *testing.T) {
+	result := &mcp.CallToolResult{}
+	got := extractToolResultError(result)
+	if got != "unknown tool error" {
+		t.Errorf("expected %q, got %q", "unknown tool error", got)
+	}
+}
+
+func TestExtractToolResultError_TextContent(t *testing.T) {
+	result := &mcp.CallToolResult{
+		Content: []mcp.Content{mcp.TextContent{Text: "something exploded"}},
+	}
+	got := extractToolResultError(result)
+	if got != "something exploded" {
+		t.Errorf("expected %q, got %q", "something exploded", got)
+	}
+}
+
+func TestExtractToolResultError_NonTextContent(t *testing.T) {
+	result := &mcp.CallToolResult{
+		Content: []mcp.Content{mcp.ImageContent{Data: "abc", MIMEType: "image/png"}},
+	}
+	got := extractToolResultError(result)
+	if got != "tool error (non-text content)" {
+		t.Errorf("expected %q, got %q", "tool error (non-text content)", got)
+	}
+}
+
+// =============================================================================
+// RegisterHooks — invoke callbacks directly via exported hook slices
+// =============================================================================
+
+func TestRegisterHooks_BeforeCallTool(t *testing.T) {
+	al := newTestLogger(t)
+	hooks := &server.Hooks{}
+	RegisterHooks(hooks, al)
+
+	req := &mcp.CallToolRequest{}
+	req.Params.Name = "find_and_click"
+	req.Params.Arguments = map[string]any{"text": "OK"}
+
+	for _, fn := range hooks.OnBeforeCallTool {
+		fn(context.Background(), nil, req)
+	}
+
+	entries := readEntries(t, al)
+	found := false
+	for _, e := range entries {
+		if e.Event == EventToolCall && e.Tool == "find_and_click" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected TOOL_CALL entry for find_and_click, got entries: %v", entries)
+	}
+}
+
+func TestRegisterHooks_AfterCallTool_Success(t *testing.T) {
+	al := newTestLogger(t)
+	hooks := &server.Hooks{}
+	RegisterHooks(hooks, al)
+
+	req := &mcp.CallToolRequest{}
+	req.Params.Name = "move_mouse"
+	result := &mcp.CallToolResult{IsError: false}
+
+	for _, fn := range hooks.OnAfterCallTool {
+		fn(context.Background(), nil, req, result)
+	}
+
+	entries := readEntries(t, al)
+	found := false
+	for _, e := range entries {
+		if e.Event == EventToolSuccess && e.Tool == "move_mouse" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected TOOL_SUCCESS entry, got entries: %v", entries)
+	}
+}
+
+func TestRegisterHooks_AfterCallTool_Screenshot(t *testing.T) {
+	al := newTestLogger(t)
+	hooks := &server.Hooks{}
+	RegisterHooks(hooks, al)
+
+	req := &mcp.CallToolRequest{}
+	req.Params.Name = "take_screenshot"
+	result := &mcp.CallToolResult{IsError: false}
+
+	for _, fn := range hooks.OnAfterCallTool {
+		fn(context.Background(), nil, req, result)
+	}
+
+	entries := readEntries(t, al)
+	found := false
+	for _, e := range entries {
+		if e.Event == EventScreenshot {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected SCREENSHOT_REQUESTED entry, got entries: %v", entries)
+	}
+}
+
+func TestRegisterHooks_AfterCallTool_Failure(t *testing.T) {
+	al := newTestLogger(t)
+	hooks := &server.Hooks{}
+	RegisterHooks(hooks, al)
+
+	req := &mcp.CallToolRequest{}
+	req.Params.Name = "click"
+	result := &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{mcp.TextContent{Text: "coords out of range"}},
+	}
+
+	for _, fn := range hooks.OnAfterCallTool {
+		fn(context.Background(), nil, req, result)
+	}
+
+	entries := readEntries(t, al)
+	found := false
+	for _, e := range entries {
+		if e.Event == EventToolFailure && e.Tool == "click" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected TOOL_FAILURE entry, got entries: %v", entries)
+	}
+}
+
+func TestRegisterHooks_OnError_AuthFailure(t *testing.T) {
+	al := newTestLogger(t)
+	hooks := &server.Hooks{}
+	RegisterHooks(hooks, al)
+
+	for _, fn := range hooks.OnError {
+		fn(context.Background(), nil, mcp.MethodToolsCall, nil, ErrAuthFailed)
+	}
+
+	entries := readEntries(t, al)
+	found := false
+	for _, e := range entries {
+		if e.Event == EventAuthFailure {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected AUTH_FAILURE entry, got entries: %v", entries)
+	}
+}
+
+func TestRegisterHooks_OnError_Other(t *testing.T) {
+	al := newTestLogger(t)
+	hooks := &server.Hooks{}
+	RegisterHooks(hooks, al)
+
+	for _, fn := range hooks.OnError {
+		fn(context.Background(), nil, mcp.MethodToolsCall, nil, errors.New("unexpected error"))
+	}
+
+	entries := readEntries(t, al)
+	found := false
+	for _, e := range entries {
+		if e.Event == EventRequestError {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected REQUEST_ERROR entry, got entries: %v", entries)
+	}
+}
+
+func TestRegisterHooks_OnError_NilIgnored(t *testing.T) {
+	al := newTestLogger(t)
+	hooks := &server.Hooks{}
+	RegisterHooks(hooks, al)
+
+	// nil error must not panic or log anything
+	for _, fn := range hooks.OnError {
+		fn(context.Background(), nil, mcp.MethodToolsCall, nil, nil)
+	}
+}
+
+func TestRegisterHooks_AfterInitialize_NilRequest(t *testing.T) {
+	al := newTestLogger(t)
+	hooks := &server.Hooks{}
+	RegisterHooks(hooks, al)
+
+	// nil request must not panic
+	for _, fn := range hooks.OnAfterInitialize {
+		fn(context.Background(), nil, nil, nil)
+	}
+}

--- a/internal/learner/learner_test.go
+++ b/internal/learner/learner_test.go
@@ -774,3 +774,76 @@ func BenchmarkAssociateLabels_LargeForm(b *testing.B) {
 		AssociateLabels(elements)
 	}
 }
+
+// =============================================================================
+// GetPageScreenshot
+// =============================================================================
+
+func TestGetPageScreenshot_NoView(t *testing.T) {
+	l := New()
+	l.Enable()
+	if got := l.GetPageScreenshot(0); got != nil {
+		t.Errorf("expected nil with no view, got %v", got)
+	}
+}
+
+func TestGetPageScreenshot_PageExists(t *testing.T) {
+	l := New()
+	l.Enable()
+	jpeg := []byte{0xFF, 0xD8, 0xFF, 0xD9}
+	l.SetView(&View{
+		Pages: []PageSnapshot{{Index: 0, JPEG: jpeg}},
+	})
+	got := l.GetPageScreenshot(0)
+	if len(got) != len(jpeg) {
+		t.Errorf("expected %d bytes, got %d", len(jpeg), len(got))
+	}
+}
+
+func TestGetPageScreenshot_PageMissing(t *testing.T) {
+	l := New()
+	l.Enable()
+	l.SetView(&View{
+		Pages: []PageSnapshot{{Index: 0, JPEG: []byte{1, 2, 3}}},
+	})
+	if got := l.GetPageScreenshot(1); got != nil {
+		t.Errorf("expected nil for missing page, got %v", got)
+	}
+}
+
+// =============================================================================
+// isRadioText — symbol coverage
+// =============================================================================
+
+func TestIsRadioText_Symbols(t *testing.T) {
+	for _, sym := range []string{"○", "●", "◉", "◎"} {
+		if !isRadioText(sym) {
+			t.Errorf("isRadioText(%q) = false, want true", sym)
+		}
+	}
+}
+
+// =============================================================================
+// isSliderText — symbol coverage
+// =============================================================================
+
+func TestIsSliderText_Symbols(t *testing.T) {
+	for _, sym := range []string{"─●", "▬●", "│●"} {
+		if !isSliderText(sym) {
+			t.Errorf("isSliderText(%q) = false, want true", sym)
+		}
+	}
+}
+
+// =============================================================================
+// isNumericValue — currency symbol coverage
+// =============================================================================
+
+func TestIsNumericValue_Currency(t *testing.T) {
+	cases := []string{"€99", "£50", "¥1000", "₹500", "$9.99"}
+	for _, s := range cases {
+		if !isNumericValue(s) {
+			t.Errorf("isNumericValue(%q) = false, want true", s)
+		}
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,77 @@
+// logging_test.go — Tests for stderr logging helpers.
+package logging
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStderr redirects os.Stderr to a pipe for the duration of f,
+// then returns everything written to it.
+func captureStderr(t *testing.T, f func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = old })
+
+	f()
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestInfo(t *testing.T) {
+	got := captureStderr(t, func() {
+		Info("hello %s", "world")
+	})
+	if !strings.Contains(got, "[INFO]") {
+		t.Errorf("expected [INFO] prefix, got: %q", got)
+	}
+	if !strings.Contains(got, "hello world") {
+		t.Errorf("expected message body, got: %q", got)
+	}
+}
+
+func TestError(t *testing.T) {
+	got := captureStderr(t, func() {
+		Error("something went %s", "wrong")
+	})
+	if !strings.Contains(got, "[ERROR]") {
+		t.Errorf("expected [ERROR] prefix, got: %q", got)
+	}
+	if !strings.Contains(got, "something went wrong") {
+		t.Errorf("expected message body, got: %q", got)
+	}
+}
+
+func TestDebug_Disabled(t *testing.T) {
+	t.Setenv("GHOST_MCP_DEBUG", "")
+	got := captureStderr(t, func() {
+		Debug("should not appear")
+	})
+	if got != "" {
+		t.Errorf("expected no output when debug disabled, got: %q", got)
+	}
+}
+
+func TestDebug_Enabled(t *testing.T) {
+	t.Setenv("GHOST_MCP_DEBUG", "1")
+	got := captureStderr(t, func() {
+		Debug("debug message %d", 42)
+	})
+	if !strings.Contains(got, "[DEBUG]") {
+		t.Errorf("expected [DEBUG] prefix, got: %q", got)
+	}
+	if !strings.Contains(got, "debug message 42") {
+		t.Errorf("expected message body, got: %q", got)
+	}
+}

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -4,9 +4,12 @@ package transport
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/ghost-mcp/internal/audit"
+	"github.com/mark3labs/mcp-go/server"
 )
 
 // =============================================================================
@@ -191,5 +194,44 @@ func TestBearerMiddleware_InnerHandlerNotCalledOnFailure(t *testing.T) {
 
 	if called {
 		t.Error("Inner handler should not be called when auth fails")
+	}
+}
+
+// =============================================================================
+// ServeHTTP
+// =============================================================================
+
+func TestServeHTTP_InvalidAddr(t *testing.T) {
+	al := newTestAuditLogger(t)
+	mcpSrv := server.NewMCPServer("test", "1.0")
+	shutdownCh := make(chan struct{})
+	cfg := Config{Mode: HTTP, Addr: "localhost:99999", BaseURL: "http://localhost:99999"}
+
+	err := ServeHTTP(shutdownCh, mcpSrv, cfg, "token", al)
+	if err == nil {
+		t.Error("expected error for invalid port 99999, got nil")
+	}
+}
+
+func TestServeHTTP_ImmediateShutdown(t *testing.T) {
+	al := newTestAuditLogger(t)
+	mcpSrv := server.NewMCPServer("test", "1.0")
+
+	shutdownCh := make(chan struct{})
+	close(shutdownCh) // already closed — shutdown fires before server loops
+
+	cfg := Config{Mode: HTTP, Addr: "localhost:18766", BaseURL: "http://localhost:18766"}
+
+	done := make(chan error, 1)
+	go func() { done <- ServeHTTP(shutdownCh, mcpSrv, cfg, "token", al) }()
+
+	select {
+	case err := <-done:
+		// nil or a "server closed" error are both acceptable outcomes
+		if err != nil && !strings.Contains(err.Error(), "closed") && !strings.Contains(err.Error(), "use of closed") {
+			t.Logf("ServeHTTP returned non-fatal error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("ServeHTTP did not return within 5 seconds after shutdown signal")
 	}
 }


### PR DESCRIPTION
- internal/logging: new logging_test.go, 0% → 100% Tests Info, Error, Debug (enabled/disabled) via stderr capture

- internal/audit: new audit_hooks_test.go, 59% → 83% Tests extractToolResultError (all branches) and RegisterHooks callbacks (BeforeCallTool, AfterCallTool success/failure/screenshot, OnError auth/other/nil, AfterInitialize nil-guard)

- internal/transport: add ServeHTTP tests, 57% → 95% Tests invalid-addr error path and immediate-shutdown path

- internal/learner: add edge-case tests, 93% → 97% Tests GetPageScreenshot (no view, exists, missing page) and symbol patterns for isRadioText, isSliderText, isNumericValue